### PR TITLE
remove severity text description from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/finding.md
+++ b/.github/ISSUE_TEMPLATE/finding.md
@@ -6,8 +6,6 @@ labels: ''
 assignees: ''
 ---
 
-**Severity:** *Critical Risk* / *High Risk* / *Medium Risk* / *Low Risk* / *Informational* / *Gas Optimization*
-
 **Context:** [File.sol#L123](github-permalink)
 
 **Description:**


### PR DESCRIPTION
text descriptions are redundant as we use labels. copy of some other relevant discussions:

cbym
> There isn’t any issue per-se with removing the severity text from issues, but it does help readability when users scan through the report. Often times users can see themselves scrolling, reading an issue and not knowing its severity, therefore have to scroll up until they find the severity category and scroll back again to continue reading… 

cmichel
> I'd say that this can be solved in the report generation script by inserting the text as the first item if it's really needed. We should make writing issues as simple as possible and furthermore manually keeping the text in sync with severity label changes is easy to forget 
